### PR TITLE
Change from repeat loop to idle loop

### DIFF
--- a/weathercat_mqtt_publish.scpt
+++ b/weathercat_mqtt_publish.scpt
@@ -5,66 +5,70 @@ property _lcChars_ : "aäáàâãåăąæbcçćčdďđeéèêëěęfghiíìîïj
 	"oöóòôõőøpqrŕřsşšśtťţuüúùûůűvwxyýzžźżþ"
 
 on idle
-	tell application "WeatherCat"
-		
-		-- Change these variables as you desire
-		set loopDelay to 60 -- 60 seconds 
-		set mqttServer to "127.0.0.1"
-		set mqttChannel to "weather/wirrimbi/"
-		set mqttSession to "WeatherCatData"
-		
-		set oldCurrentConditions to ""
-		set oldDriverStatus to ""
-		
-		set quantum to 0.1 -- Used for rounding data to 1 decimal place
-		
-		
-		-- Initialise the previous values list
-		set previousValues to {} -- array/list of previous values
-		repeat NumberOfChannels times
-			set end of previousValues to ""
-		end repeat
-		
-		-- Get the Station Driver Status (true or false)
-		set driverStatus to StationDriverStatus
-		if oldDriverStatus is not driverStatus then
-			do shell script "/usr/local/bin/mosquitto_pub -q 1 --disable-clean-session -i " & mqttSession & " -h " & mqttServer & " -t '" & mqttChannel & "text/station_driver_status/' -m " & driverStatus
-		end if
-		set oldDriverStatus to driverStatus
-		
-		-- Get the Current Conditions (text)
-		
-		set currConditions to CurrentConditions
-		if oldCurrentConditions is not currConditions then
-			do shell script "/usr/local/bin/mosquitto_pub -q 1 --disable-clean-session -i " & mqttSession & " -h " & mqttServer & " -t '" & mqttChannel & "text/current_conditions/' -m '" & currConditions & "'"
-		end if
-		set oldCurrentConditions to currConditions
-		
-		repeat with theIncrementValue from 1 to NumberOfChannels
-			set WorkingChannel to theIncrementValue
-			set wcname to WorkingChannelName
-			set wcvalue to (round WorkingChannelValue / quantum) * quantum
-			set wcstatus to WorkingChannelStatus
-			
-			-- Set the previous value from the list
-			set wcpreviousvalue to item theIncrementValue of previousValues
-			
-			-- If the WeatherCat channel is OK and the value has changed then publish
-			if wcname is not missing value and wcstatus is true and wcpreviousvalue is not wcvalue then
-				
-				set wcnamecleaned to my replaceString(wcname, " ", "_")
-				set wcnamecleaned to my replaceString(wcnamecleaned, ".", "")
-				set wcnamecleaned to my replaceString(wcnamecleaned, "(", "")
-				set wcnamecleaned to my replaceString(wcnamecleaned, ")", "")
-				
-				set wcnamecleaned to my lowerString(wcnamecleaned)
-				
-				do shell script "/usr/local/bin/mosquitto_pub -q 1 --disable-clean-session -i " & mqttSession & " -h " & mqttServer & " -t '" & mqttChannel & "channel/" & wcnamecleaned & "/' -m " & wcvalue
-			end if
-			set item theIncrementValue of previousValues to wcvalue
-			
-		end repeat
-	end tell
+	try
+		with timeout of 30 seconds
+			tell application "WeatherCat"
+
+				-- Change these variables as you desire
+				set loopDelay to 90 -- 60 seconds 
+				set mqttServer to "127.0.0.1"
+				set mqttChannel to "weather/wirrimbi/"
+				set mqttSession to "WeatherCatData"
+
+				set oldCurrentConditions to ""
+				set oldDriverStatus to ""
+
+				set quantum to 0.1 -- Used for rounding data to 1 decimal place
+
+
+				-- Initialise the previous values list
+				set previousValues to {} -- array/list of previous values
+				repeat NumberOfChannels times
+					set end of previousValues to ""
+				end repeat
+
+				-- Get the Station Driver Status (true or false)
+				set driverStatus to StationDriverStatus
+				if oldDriverStatus is not driverStatus then
+					do shell script "/usr/local/bin/mosquitto_pub -q 1 --disable-clean-session -i " & mqttSession & " -h " & mqttServer & " -t '" & mqttChannel & "text/station_driver_status/' -m " & driverStatus
+				end if
+				set oldDriverStatus to driverStatus
+
+				-- Get the Current Conditions (text)
+
+				set currConditions to CurrentConditions
+				if oldCurrentConditions is not currConditions then
+					do shell script "/usr/local/bin/mosquitto_pub -q 1 --disable-clean-session -i " & mqttSession & " -h " & mqttServer & " -t '" & mqttChannel & "text/current_conditions/' -m '" & currConditions & "'"
+				end if
+				set oldCurrentConditions to currConditions
+
+				repeat with theIncrementValue from 1 to NumberOfChannels
+					set WorkingChannel to theIncrementValue
+					set wcname to WorkingChannelName
+					set wcvalue to (round WorkingChannelValue / quantum) * quantum
+					set wcstatus to WorkingChannelStatus
+
+					-- Set the previous value from the list
+					set wcpreviousvalue to item theIncrementValue of previousValues
+
+					-- If the WeatherCat channel is OK and the value has changed then publish
+					if wcname is not missing value and wcstatus is true and wcpreviousvalue is not wcvalue then
+
+						set wcnamecleaned to my replaceString(wcname, " ", "_")
+						set wcnamecleaned to my replaceString(wcnamecleaned, ".", "")
+						set wcnamecleaned to my replaceString(wcnamecleaned, "(", "")
+						set wcnamecleaned to my replaceString(wcnamecleaned, ")", "")
+
+						set wcnamecleaned to my lowerString(wcnamecleaned)
+
+						do shell script "/usr/local/bin/mosquitto_pub -q 1 --disable-clean-session -i " & mqttSession & " -h " & mqttServer & " -t '" & mqttChannel & "channel/" & wcnamecleaned & "/' -m " & wcvalue
+					end if
+					set item theIncrementValue of previousValues to wcvalue
+
+				end repeat
+			end tell
+		end timeout
+	end try
 	return loopDelay
 end idle
 

--- a/weathercat_mqtt_publish.scpt
+++ b/weathercat_mqtt_publish.scpt
@@ -8,7 +8,7 @@ on idle
 	tell application "WeatherCat"
 		
 		-- Change these variables as you desire
-		set loopDelay to 30 -- 30 seconds (plus idler will be called by OS after 30 sec - total 60)
+		set loopDelay to 60 -- 60 seconds 
 		set mqttServer to "127.0.0.1"
 		set mqttChannel to "weather/wirrimbi/"
 		set mqttSession to "WeatherCatData"


### PR DESCRIPTION
Changed the repeat loop to an idle loop.  This allows the script to be interrupted (eg to shut down) without a force quit and should also be more resource efficient.  As the script technically exits each time, a persistent session is used with Mosquitto.  The default idle loop is (from memory) either 30 or 60 sec (did this a while ago) but it is modified by the loop return value (hence loopDelay is retained).  The mqttChannel was changed for my system!

This updated script was saved as an executable and run on startup.  It has been running with WeatherCat 3.x/MacOS 10.15.x since the Jul commit pretty much full time.  Occasionally (2 or 3 times) it has failed to talk to WeatherCat and errored.  A restart of the script was all that was needed.  It has subsequently been updated to include a try section with explicit timeout.  To date this seems to have fixed the errors.